### PR TITLE
Fixed content overflow for small parent objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ After you added the package, all you need to do is import it and you can add a t
 
 ## Usage
 
-### Example 1
+### Basic use case
 
 As the first example, the `Text` view is provided as the tooltip content and it's attached to the other `Text` view.
 Below you can see the example of code that is required to create the tooltip and the result you see on the screen.
@@ -41,7 +41,7 @@ Text("Say something nice...")
 
 ![example 1](images/example_1.jpg)
 
-### Example 2
+### Using custom configuration to add a jumping animation
 
 Second example shows you how you can add jumping animation to the tooltip from the first example.
 

--- a/Sources/SwiftUITooltip/TooltipModifier.swift
+++ b/Sources/SwiftUITooltip/TooltipModifier.swift
@@ -178,6 +178,7 @@ struct TooltipModifier<TooltipContent: View>: ViewModifier {
                 ZStack {
                     content
                         .padding(self.config.contentPaddingEdgeInsets)
+                        .fixedSize()
                 }
                 .background(self.sizeMeasurer)
                     .overlay(self.arrowView)


### PR DESCRIPTION
## Notes

Closes #11. Thanks @chrysb for the issue.

## Problem

The content was overflowing if you set the `.frame` of the element you attach tooltip to too small.

## Solution

- Added `.fixedSize` to content inside of `ViewModifier`

## Screenshots

### Code used for screenshots below

```swift
Circle()
  .fill(Color.green)
  .frame(width: 36, height: 36)
  .tooltip(.top) {
    Text("Tap here")
  }
```

### Before fix

<img width="238" alt="before" src="https://user-images.githubusercontent.com/29360707/127875934-50c404f2-a5c3-4af6-97b1-04190928ff9e.png">

### After fix

<img width="230" alt="after" src="https://user-images.githubusercontent.com/29360707/127875955-65c83208-9b93-48af-a6bb-add97936f67f.png">
